### PR TITLE
Ray-tracer crop window

### DIFF
--- a/rt-proj-01/src/core/api.cpp
+++ b/rt-proj-01/src/core/api.cpp
@@ -14,7 +14,6 @@ void render(Film *film, Background *bckg, RunningOptions &opt) {
 
   if (crop_window[0][0] == 0 && crop_window[0][1] == 1 &&
       crop_window[1][0] == 0 && crop_window[1][1] == 1) {
-      std::cout << "SAME" << "\n";
       w = film->width();
       h = film->height();
   } else {
@@ -25,16 +24,14 @@ void render(Film *film, Background *bckg, RunningOptions &opt) {
             << crop_window[1][1] << ")" << std::endl;
     w = crop_window[0][1] - crop_window[0][0] + 1;
     h = crop_window[1][1] - crop_window[1][0] + 1;
+    std::cout << "W:" << crop_window[0][1] - crop_window[0][0] + 1 << '\n';
+    std::cout << "H:" << crop_window[1][1] - crop_window[1][0] + 1<< '\n';
   }
 
 
   for(int i = 0; i < h; i++) {
     for(int j = 0; j < w; j++) {
       Color c;
-      // if (crop_start_x != 0 || crop_end_x != 1 || crop_start_y != 0 || crop_end_y != 1) {
-      //   c = bckg->sampleXYZ({float(j + crop_start_x)/float(w), float(i + crop_start_y)/float(h)});
-      // } else {
-      // }
       c = bckg->sampleXYZ({float(j)/float(w), float(i)/float(h)});
       film->add_sample({i,j}, c);
     }

--- a/rt-proj-01/src/core/api.cpp
+++ b/rt-proj-01/src/core/api.cpp
@@ -6,17 +6,37 @@
 
 namespace rt3 {
 
-void render(Film *film, Background *bckg) {
+void render(Film *film, Background *bckg, RunningOptions opt) {
   int w = film->width();
   int h = film->height();
 
-  /* std::cout << w << " ----- " << h << std::endl; */
+  int crop_start_x = opt.crop_window[0][0];
+  int crop_end_x = opt.crop_window[1][0];
+  int crop_start_y = opt.crop_window[0][1];
+  int crop_end_y = opt.crop_window[1][1];
+
+  // Check if the crop window values are different from default
+  if (crop_start_x == 0 && crop_end_x == 1 && crop_start_y == 0 && crop_end_y == 1) {
+    std::cout << "DIFFERENT" << "\n";
+    w = film->width();
+    h = film->height();
+  } else {
+    w = film->width();
+    h = film->height();
+    // w = crop_end_x - crop_start_x + 1;
+    // h = crop_end_y - crop_start_y + 1;
+  }
+
+  std::cout << "Crop Window: (" << crop_start_x << ", " << crop_start_y << ") to (" << crop_end_x << ", " << crop_end_y << ")" << "\n";
+
   for(int i = 0; i < h; i++) {
     for(int j = 0; j < w; j++) {
-      Color c = bckg->sampleXYZ({float(j)/float(w), float(i)/float(h)});
-      //std::cout << i << " --- " << j << std::endl;
-      /* std::cout << "(render) Color in (" << i << ", " << j << ") = " 
-                << c.r << " " << c.g << " " << c.b << std::endl; */
+      Color c;
+      // if (crop_start_x != 0 || crop_end_x != 1 || crop_start_y != 0 || crop_end_y != 1) {
+      //   c = bckg->sampleXYZ({float(j + crop_start_x)/float(w), float(i + crop_start_y)/float(h)});
+      // } else {
+      // }
+      c = bckg->sampleXYZ({float(j)/float(w), float(i)/float(h)});
       film->add_sample({i,j}, c);
     }
   }
@@ -122,9 +142,7 @@ void API::world_end() {
 
     //================================================================================
     auto start = std::chrono::steady_clock::now();
-    render(the_film.get(), the_background.get());  // TODO: This is the ray tracer's  main loop.
-    std::cout << "GOT HERE:" << "\n";
-    std::cout << curr_run_opt << "\n";
+    render(the_film.get(), the_background.get(), curr_run_opt);  // TODO: This is the ray tracer's  main loop.
     auto end = std::chrono::steady_clock::now();
     //================================================================================
     auto diff = end - start;  // Store the time difference between start and end

--- a/rt-proj-01/src/core/api.cpp
+++ b/rt-proj-01/src/core/api.cpp
@@ -123,6 +123,8 @@ void API::world_end() {
     //================================================================================
     auto start = std::chrono::steady_clock::now();
     render(the_film.get(), the_background.get());  // TODO: This is the ray tracer's  main loop.
+    std::cout << "GOT HERE:" << "\n";
+    std::cout << curr_run_opt << "\n";
     auto end = std::chrono::steady_clock::now();
     //================================================================================
     auto diff = end - start;  // Store the time difference between start and end

--- a/rt-proj-01/src/core/api.cpp
+++ b/rt-proj-01/src/core/api.cpp
@@ -6,28 +6,27 @@
 
 namespace rt3 {
 
-void render(Film *film, Background *bckg, RunningOptions opt) {
+void render(Film *film, Background *bckg, RunningOptions &opt) {
   int w = film->width();
   int h = film->height();
+  auto crop_window = opt.crop_window;
 
-  int crop_start_x = opt.crop_window[0][0];
-  int crop_end_x = opt.crop_window[1][0];
-  int crop_start_y = opt.crop_window[0][1];
-  int crop_end_y = opt.crop_window[1][1];
 
-  // Check if the crop window values are different from default
-  if (crop_start_x == 0 && crop_end_x == 1 && crop_start_y == 0 && crop_end_y == 1) {
-    std::cout << "DIFFERENT" << "\n";
-    w = film->width();
-    h = film->height();
+  if (crop_window[0][0] == 0 && crop_window[0][1] == 1 &&
+      crop_window[1][0] == 0 && crop_window[1][1] == 1) {
+      std::cout << "SAME" << "\n";
+      w = film->width();
+      h = film->height();
   } else {
-    w = film->width();
-    h = film->height();
-    // w = crop_end_x - crop_start_x + 1;
-    // h = crop_end_y - crop_start_y + 1;
+    std::cout << "Crop Window: ("
+            << crop_window[0][0] << ", "
+            << crop_window[1][0] << ") to ("
+            << crop_window[0][1] << ", "
+            << crop_window[1][1] << ")" << std::endl;
+    w = crop_window[0][1] - crop_window[0][0] + 1;
+    h = crop_window[1][1] - crop_window[1][0] + 1;
   }
 
-  std::cout << "Crop Window: (" << crop_start_x << ", " << crop_start_y << ") to (" << crop_end_x << ", " << crop_end_y << ")" << "\n";
 
   for(int i = 0; i < h; i++) {
     for(int j = 0; j < w; j++) {

--- a/rt-proj-01/src/core/film.cpp
+++ b/rt-proj-01/src/core/film.cpp
@@ -93,7 +93,6 @@ Film* create_film(const ParamSet& ps) {
   // TODO
   // Read crop window information.
   std::vector<real_type> cw = retrieve(ps, "crop_window", std::vector<real_type>{ 0, 1, 0, 1 });
-  std::cout << "GET CROP: Crop window ";
   for (const auto& e : cw) {
     std::cout << e << " ";
   }

--- a/rt-proj-01/src/core/film.cpp
+++ b/rt-proj-01/src/core/film.cpp
@@ -92,12 +92,12 @@ Film* create_film(const ParamSet& ps) {
 
   // TODO
   // Read crop window information.
-  /*std::vector<real_type> cw = retrieve(ps, "crop_window", std::vector<real_type>{ 0, 1, 0, 1 });
-  std::cout << "Crop window ";
+  std::vector<real_type> cw = retrieve(ps, "crop_window", std::vector<real_type>{ 0, 1, 0, 1 });
+  std::cout << "GET CROP: Crop window ";
   for (const auto& e : cw) {
     std::cout << e << " ";
   }
-  std::cout << '\n';*/
+  std::cout << '\n';
 
   std::string img_t_str = retrieve(ps, "img_type", std::string{"png"});
 

--- a/rt-proj-01/src/main/rt3.cpp
+++ b/rt-proj-01/src/main/rt3.cpp
@@ -52,11 +52,6 @@ RunningOptions cli_parser(int argc, char* argv[]) {
       opt.crop_window[1][0] = std::stof(argv[++i]);
       opt.crop_window[1][1] = std::stof(argv[++i]);
 
-      std::cout << "CROP";
-      std::cout << opt.crop_window[0][0];
-      std::cout << opt.crop_window[0][1];
-      std::cout << opt.crop_window[1][0];
-      std::cout << opt.crop_window[1][1] << '\n';
     } else if (option == "--outfile" or option == "-outfile" or option == "-o") {
       if (i + 1 == argc) {  // The option's argument is missing.
         usage("missing value after --outfile argument");

--- a/rt-proj-01/src/main/rt3.cpp
+++ b/rt-proj-01/src/main/rt3.cpp
@@ -51,6 +51,12 @@ RunningOptions cli_parser(int argc, char* argv[]) {
       opt.crop_window[0][1] = std::stof(argv[++i]);
       opt.crop_window[1][0] = std::stof(argv[++i]);
       opt.crop_window[1][1] = std::stof(argv[++i]);
+
+      std::cout << "CROP";
+      std::cout << opt.crop_window[0][0];
+      std::cout << opt.crop_window[0][1];
+      std::cout << opt.crop_window[1][0];
+      std::cout << opt.crop_window[1][1] << '\n';
     } else if (option == "--outfile" or option == "-outfile" or option == "-o") {
       if (i + 1 == argc) {  // The option's argument is missing.
         usage("missing value after --outfile argument");


### PR DESCRIPTION
Optei por fazer uma solução Ad-Hoc e ir direto ao ponto no film. Ao receber o crop window como parâmetro, (deve ser diferente de 0 1 0 1), será passado o valor como parâmetro para o render e se for diferente do default, o novo `w` e `h` será calculado. Por favor, checar se o cálculo está certo. 

Corrigir a ordem dos prints talvez seja necessário para evitar duplas interpretações.