### PR TITLE
Implementing crop window from XML

### DIFF
--- a/rt-proj-01/scene/scene_03.xml
+++ b/rt-proj-01/scene/scene_03.xml
@@ -1,7 +1,7 @@
 <RT3>
     <lookat look_from="0 7 0" look_at="0 0 0" up="0 0 1" />
     <camera type="orthographic" screen_window="-1.7 1.7 -1 1"/>
-    <film type="image" x_res="1920" y_res="1080" crop_window="0.1 0.3 0 1"
+    <film type="image" x_res="1920" y_res="1080" crop_window="150 250 50 100"
         filename="images/scene_03.png"
         img_type="png"  gamma_corrected="yes" />
 

--- a/rt-proj-01/src/core/api.cpp
+++ b/rt-proj-01/src/core/api.cpp
@@ -6,26 +6,26 @@
 
 namespace rt3 {
 
-void render(Film *film, Background *bckg, RunningOptions &opt) {
+void render(Film *film, Background *bckg, RunningOptions &opt, vector<real_type> cw) {
   int w = film->width();
   int h = film->height();
+
   auto crop_window = opt.crop_window;
 
-
-  if (crop_window[0][0] == 0 && crop_window[0][1] == 1 &&
-      crop_window[1][0] == 0 && crop_window[1][1] == 1) {
-      w = film->width();
-      h = film->height();
+  if (cw[0] == 0 && cw[1] == 1 && cw[2] == 0 && cw[3] == 1) {
+    if (crop_window[0][0] == 0 && crop_window[0][1] == 1 && crop_window[1][0] == 0 && crop_window[1][1] == 1) {
+        std::cout << "--> Using default crop window." << std::endl;
+        w = film->width();
+        h = film->height();
+    } else {
+        std::cout << "--> Using crop window from flag." << std::endl;
+        w = crop_window[1][1] - crop_window[1][0] + 1;
+        h = crop_window[0][1] - crop_window[0][0] + 1;
+    }
   } else {
-    std::cout << "Crop Window: ("
-            << crop_window[0][0] << ", "
-            << crop_window[1][0] << ") to ("
-            << crop_window[0][1] << ", "
-            << crop_window[1][1] << ")" << std::endl;
-    w = crop_window[0][1] - crop_window[0][0] + 1;
-    h = crop_window[1][1] - crop_window[1][0] + 1;
-    std::cout << "W:" << crop_window[0][1] - crop_window[0][0] + 1 << '\n';
-    std::cout << "H:" << crop_window[1][1] - crop_window[1][0] + 1<< '\n';
+      std::cout << "--> Using custom crop window." << std::endl;
+      w = cw[1] - cw[0] + 1;
+      h = cw[3] - cw[2] + 1;
   }
 
 
@@ -138,7 +138,14 @@ void API::world_end() {
 
     //================================================================================
     auto start = std::chrono::steady_clock::now();
-    render(the_film.get(), the_background.get(), curr_run_opt);  // TODO: This is the ray tracer's  main loop.
+
+    std::vector<real_type> cw = retrieve(render_opt->film_ps, "crop_window", std::vector<real_type>{ 0, 1, 0, 1 });
+    cout << "STRING HERE:" << std::endl;
+    for (const auto& e : cw) {
+      std::cout << e << " ";
+    }
+
+    render(the_film.get(), the_background.get(), curr_run_opt, cw);  // TODO: This is the ray tracer's  main loop.
     auto end = std::chrono::steady_clock::now();
     //================================================================================
     auto diff = end - start;  // Store the time difference between start and end

--- a/rt-proj-01/src/core/api.cpp
+++ b/rt-proj-01/src/core/api.cpp
@@ -140,11 +140,6 @@ void API::world_end() {
     auto start = std::chrono::steady_clock::now();
 
     std::vector<real_type> cw = retrieve(render_opt->film_ps, "crop_window", std::vector<real_type>{ 0, 1, 0, 1 });
-    cout << "STRING HERE:" << std::endl;
-    for (const auto& e : cw) {
-      std::cout << e << " ";
-    }
-
     render(the_film.get(), the_background.get(), curr_run_opt, cw);  // TODO: This is the ray tracer's  main loop.
     auto end = std::chrono::steady_clock::now();
     //================================================================================


### PR DESCRIPTION
 Nessa modificação, adicionei um parâmetro a mais chamado `cw` do tipo `std::vector<real_type>` dentro do método `render()`. Dessa forma, temos os parâmetros do crop window vindos da flag e do arquivo xml. Caso nada tenha sido informado no xml, o valor default será `0 1 0 1`. A mesma coisa para o parâmetro vindo da flag `--cropwindow`. Um `if` statement faz a checagem e decide qual valor será utilizado. Um log é exibido para o usuário, informando qual valor ele "pegou".
 Eu modifiquei o arquivo `scene_03.xml` para que os parâmetros do xml correspondam ao padrão que estamos utilizando, isto é, valores absolutos. Com os valores colocados no crop window, uma imagem será gerada assim:

![Screenshot from 2024-03-22 10-43-32](https://github.com/PauloVLB/Ray-Tracer/assets/24938005/a3b7b7d1-c34c-44ab-93f3-c9a78a699c46)


